### PR TITLE
Add team response column to issues pending response table

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -47,6 +47,7 @@ export class Issue {
   issueDisputes?: IssueDispute[];
   teamChosenSeverity?: string;
   teamChosenType?: string;
+  teamChosenResponse?: string;
   teamAccepted?: boolean;
 
   /** Fields for error messages during parsing of Github's issue description */
@@ -162,6 +163,7 @@ export class Issue {
 
     issue.teamChosenSeverity = testerResponseTemplate.teamChosenSeverity || null;
     issue.teamChosenType = testerResponseTemplate.teamChosenType || null;
+    issue.teamChosenResponse = testerResponseTemplate.teamChosenResponse || null;
 
     return issue;
   }

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -13,6 +13,7 @@ interface TesterResponseParseResult {
   testerDisagree: boolean;
   teamChosenSeverity: string;
   teamChosenType: string;
+  teamChosenResponse: string;
 }
 
 const GITHUB_UI_EDIT_WARNING =
@@ -37,6 +38,7 @@ export const TesterResponseParser = coroutine(function* () {
   let testerDisagree = false;
   let teamChosenSeverity: string;
   let teamChosenType: string;
+  let teamChosenResponse: string;
   const testerResponses: TesterResponse[] = [];
 
   for (const response of responses) {
@@ -48,6 +50,8 @@ export const TesterResponseParser = coroutine(function* () {
       teamChosenSeverity = response.teamChose;
     } else if (response.title === 'type') {
       teamChosenType = response.teamChose;
+    } else if (response.title === 'response') {
+      teamChosenResponse = response.teamChose;
     }
 
     testerResponses.push(
@@ -66,7 +70,8 @@ export const TesterResponseParser = coroutine(function* () {
     testerResponses: testerResponses,
     testerDisagree: testerDisagree,
     teamChosenSeverity: teamChosenSeverity,
-    teamChosenType: teamChosenType
+    teamChosenType: teamChosenType,
+    teamChosenResponse: teamChosenResponse
   };
   return result;
 });
@@ -78,6 +83,7 @@ export class TesterResponseTemplate extends Template {
   comment: IssueComment;
   teamChosenSeverity?: string;
   teamChosenType?: string;
+  teamChosenResponse?: string;
 
   constructor(githubComments: GithubComment[]) {
     super(TesterResponseParser);
@@ -98,5 +104,6 @@ export class TesterResponseTemplate extends Template {
     this.testerDisagree = this.parseResult.testerDisagree;
     this.teamChosenSeverity = this.parseResult.teamChosenSeverity;
     this.teamChosenType = this.parseResult.teamChosenType;
+    this.teamChosenResponse = this.parseResult.teamChosenResponse;
   }
 }

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
@@ -11,7 +11,14 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 export class IssuePendingComponent implements OnInit {
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  readonly displayedColumns = [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
+  readonly displayedColumns = [
+    TABLE_COLUMNS.ID,
+    TABLE_COLUMNS.TITLE,
+    TABLE_COLUMNS.TEAM_RESPONSE,
+    TABLE_COLUMNS.TYPE,
+    TABLE_COLUMNS.SEVERITY,
+    TABLE_COLUMNS.ACTIONS
+  ];
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
     ACTION_BUTTONS.RESPOND_TO_ISSUE,

--- a/src/app/shared/issue-tables/issue-tables-columns.ts
+++ b/src/app/shared/issue-tables/issue-tables-columns.ts
@@ -4,6 +4,7 @@ export enum TABLE_COLUMNS {
   TEAM_ASSIGNED = 'teamAssigned',
   TYPE = 'type',
   SEVERITY = 'severity',
+  TEAM_RESPONSE = 'teamResponse',
   RESPONSE = 'response',
   TESTER_DISAGREE = 'testerDisagree',
   ASSIGNEE = 'assignees',

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -27,9 +27,9 @@
     <mat-cell *matCellDef="let issue">
       <span
         (click)="$event.stopPropagation()"
-        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel('response', issue.teamResponse))"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel('response', issue.teamChosenResponse))"
       >
-        {{ issue.teamResponse || '-' }}
+        {{ issue.teamChosenResponse || '-' }}
       </span>
     </mat-cell>
   </ng-container>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -23,7 +23,7 @@
 
   <!-- Team Response Column -->
   <ng-container matColumnDef="teamResponse">
-    <mat-header-cell *matHeaderCellDef mat-sort-header> Team Response </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Team's Response </mat-header-cell>
     <mat-cell *matCellDef="let issue">
       <span
         (click)="$event.stopPropagation()"

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -21,6 +21,19 @@
     <mat-cell *matCellDef="let issue"> {{ (issue.teamAssigned && issue.teamAssigned.id) || '-' }} </mat-cell>
   </ng-container>
 
+  <!-- Team Response Column -->
+  <ng-container matColumnDef="teamResponse">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Team Response </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
+      <span
+        (click)="$event.stopPropagation()"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel('response', issue.teamResponse))"
+      >
+        {{ issue.teamResponse || '-' }}
+      </span>
+    </mat-cell>
+  </ng-container>
+
   <!-- Type Column -->
   <ng-container matColumnDef="type">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Type </mat-header-cell>


### PR DESCRIPTION
### Summary:
Add a "Team's Response" column to Issues Pending Response table in Tester Response Phase

Before:
![image](https://github.com/jonasongg/CATcher/assets/120372506/158cccad-9096-4679-ad5e-7f54c70e0cc4)

After:
![image](https://github.com/jonasongg/CATcher/assets/120372506/0b447747-ec21-4e29-8352-d06a8982b3af)

### Changes Made:
* Add `teamChosenResponse` to the `issue.model.ts` and `tester-response-template.model.ts`
* Add column to `issue-pending.component.ts`, `issue-tables-columns.ts`, and `issue-tables.component.html`

### Proposed Commit Message:
```
Add team response column to issues pending response table

Testers currently need to click into each issue to see what the dev
team response is.

Let's show the response on the outside table.
```
